### PR TITLE
readme: update flake url

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ The main differences are:
 
 ### nix-flakes:
 
-nix-wrangle (like [niv][]) is similar in spirit to [nix flakes](https://gist.github.com/edolstra/40da6e3a4d4ee8fd019395365e0772e7), but there's no actual implementation of flakes yet. My hope is that any standard solution would be able to support nix-wrangle style workflows.
+nix-wrangle (like [niv][]) is similar in spirit to [nix flakes](https://github.com/tweag/rfcs/blob/flakes/rfcs/0049-flakes.md), but the implementation is still experimental. My hope is that any standard solution would be able to support nix-wrangle style workflows.
 
 [niv]: https://github.com/nmattia/niv
 


### PR DESCRIPTION
Pointed reference to working directory of rfc, as to refer to most update to date information. Also slightly changed the wording to reflect that an implementation has materialized.